### PR TITLE
Improved readability on <aside> list items

### DIFF
--- a/public/css/screen.css
+++ b/public/css/screen.css
@@ -849,6 +849,9 @@ aside ul:first-child {
 
 aside li {
 	list-style-type: none;
+	line-height: 0.7em;
+	margin-bottom: 0.5em;
+	margin-top: 0.5em;
 }
 
 aside li a {


### PR DESCRIPTION
This makes it so each item on the list that spans two (or more) lines is shown in a more compact way. Otherwise the list is very hard to read.

Thus turning this: 
![](http://i824.photobucket.com/albums/zz163/chillfok/before_zps268a5c0f.png)

into this:
![](http://i824.photobucket.com/albums/zz163/chillfok/after_zps196f57ac.png)
