### PR TITLE
Use css selectors insead of preg to select html

### DIFF
--- a/module/Documentation/view/documentation/toc.phtml
+++ b/module/Documentation/view/documentation/toc.phtml
@@ -1,9 +1,14 @@
 <aside class="toc">
-<?php 
+<?php
     $toc     = $this->manualpage('TOC', $this->model, false);
     $baseUri = $this->url('documentation', array(), false);
     $current = sprintf('%s/%s', $baseUri, $this->current);
-    $toc     = preg_replace('#<li>(<a href="' . $current . '")#s', '<li class="current">$1', $toc);
     echo $toc;
 ?>
 </aside>
+
+<script>
+Zepto(function($) {
+    $('a[href="<?= $current; ?>"]').parent('li').addClass('current').parents('ul').show();
+});
+</script>


### PR DESCRIPTION
The Authentication `<li><a` which toc.phtml looks for is split across lines and
not found by the non-css preg selector.  

This section of TOC.md 
## Authentication and Authorization
- [Introduction](/auth/intro.md)
- [Authentication](/auth/authentication.md)
  - [HTTP Basic Auth](/auth/authentication-http-basic.md)
  - [HTTP Digest Auth](/auth/authentication-http-digest.md)
  - [OAuth2](/auth/authentication-oauth2.md)
- [Authorization](/auth/authorization.md)
- [Advanced Auth Events and Services](/auth/advanced.md)

should be
## Authentication and Authorization
- [Introduction](/auth/intro.md)
- [About Authentication](/auth/authentication-about.md)
- [HTTP Basic Authentication](/auth/authentication-http-basic.md)
- [HTTP Digest Authentication](/auth/authentication-http-digest.md)
- [OAuth2 Authentication](/auth/authentication-oauth2.md)
- [Authorization](/auth/authorization.md)
- [Advanced Auth Events and Services](/auth/advanced.md)

Nowhere else in the TOC is there a second level and this interfers with 
a more correct method of selecting the current page

``` js
<script>
Zepto(function($) {
    $('a[href="<?= $current; ?>"]').parent('li').addClass('current').parents('ul').show();
});
</script>
```

This Zepto function works fine in all cases except the second level 
because when their parent is selected and the 'current' class is 
added to it's li element the html > pointer style is duplicated across the second level.
