### PR TITLE
CURL will not follow 301

### DIFF
--- a/module/Application/view/application/home/index.phtml
+++ b/module/Application/view/application/home/index.phtml
@@ -67,7 +67,7 @@
 
 			<div class="shell">
 				<p class="line">
-					<span class="prompt">$</span> <span class="command">curl -sS http://apigility.org/install | php</span>
+					<span class="prompt">$</span> <span class="command">curl -sS https://apigility.org/install | php</span>
 				</p>
 
 				<p class="line">
@@ -75,7 +75,7 @@
 				</p>
 
 				<p class="line">
-					<span class="prompt">$</span> <span class="command">php -r "readfile('http://apigility.org/install');" | php</span>
+					<span class="prompt">$</span> <span class="command">php -r "readfile('https://apigility.org/install');" | php</span>
 				</p>
 
 				<p class="line">


### PR DESCRIPTION
I tried running the project according to the start page and found myself with a little error. 

`curl -sS http://apigility.org/install | php`

``` html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://apigility.org/install">here</a>.</p>
<hr>
<address>Apache Server at apigility.org Port 80</address>
</body></html>
```
