### PR TITLE
Added the hover effect on documentation code to improve legibility

### DIFF
--- a/public/css/screen.css
+++ b/public/css/screen.css
@@ -1063,6 +1063,10 @@ pre,code {
 	}
 }
 
+.highlight:hover {
+    width:130% !important;
+}
+
 .highlight,p>pre,p>code,p>nobr>code,li>code,h5>code,.note>code,pre>code[class*='language-'] {
 	background: #555555;
 	color: #fff;


### PR DESCRIPTION
I added the :hover css effect to expand the code box in order to improve legibility.

This is the actual situation:
![screen1](https://cloud.githubusercontent.com/assets/475967/3038612/f5aa5740-e0cf-11e3-8523-4ab027d2f29e.png)

With this PR the box will be expanded as follow, only on mouse hover:
![screen2](https://cloud.githubusercontent.com/assets/475967/3038619/06b9d31c-e0d0-11e3-8f94-80fd00c53301.png)
