### PR TITLE
Added the version support to /install

### DIFF
--- a/bin/install.php
+++ b/bin/install.php
@@ -9,7 +9,7 @@
 $localPath    = __DIR__;
 $apigilityDir = 'apigility';
 $port         = '8888';
-$releaseUrl   = 'https://github.com/zfcampus/zf-apigility-skeleton/releases/download/1.1.0/zf-apigility-skeleton-1.1.0.zip';
+$releaseUrl   = 'https://github.com/zfcampus/zf-apigility-skeleton/releases/download/1.1.0/zf-apigility-skeleton-1.3.0.zip';
 $tmpFile      = sys_get_temp_dir() . '/apigility_' . md5($releaseUrl) . '.zip';
 
 checkPlatform();
@@ -36,7 +36,7 @@ echo "\nInstall Apigility\n";
 
 $zip = new ZipArchive;
 if (!$zip->open($tmpFile)) {
-    die("Error: opening file $tmpFile\n"); 
+    die("Error: opening file $tmpFile\n");
 }
 if (!$zip->extractTo($localPath)) {
     die("Error: extract $tmpFile\n");
@@ -55,7 +55,7 @@ echo "Installation complete.\n";
 if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
     echo "Running PHP internal web server.\n";
     echo "Open your browser to http://localhost:$port, Ctrl-C to stop it.\n";
-    exec("php -S 0.0.0.0:$port -t public public/index.php");
+    exec("php -S 0.0.0.0:$port -ddisplay_errors=0 -t public public/index.php");
 } else {
     echo "I cannot execute the PHP internal web server, because you are running PHP < 5.4.\n";
     echo "You need to configure a web server to point the 'apigility/public' folder\n";

--- a/bin/install.php.dist
+++ b/bin/install.php.dist
@@ -36,7 +36,7 @@ echo "\nInstall Apigility\n";
 
 $zip = new ZipArchive;
 if (!$zip->open($tmpFile)) {
-    die("Error: opening file $tmpFile\n"); 
+    die("Error: opening file $tmpFile\n");
 }
 if (!$zip->extractTo($localPath)) {
     die("Error: extract $tmpFile\n");
@@ -55,7 +55,7 @@ echo "Installation complete.\n";
 if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
     echo "Running PHP internal web server.\n";
     echo "Open your browser to http://localhost:$port, Ctrl-C to stop it.\n";
-    exec("php -S 0.0.0.0:$port -t public public/index.php");
+    exec("php -S 0.0.0.0:$port -ddisplay_errors=0 -t public public/index.php");
 } else {
     echo "I cannot execute the PHP internal web server, because you are running PHP < 5.4.\n";
     echo "You need to configure a web server to point the 'apigility/public' folder\n";

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -13,13 +13,16 @@ return array(
                 ),
             ),
         	'install' => array(
-        		'type' => 'Zend\Mvc\Router\Http\Literal',
+        		'type' => 'Zend\Mvc\Router\Http\Segment',
         		'options' => array(
-        			'route'    => '/install',
+        			'route'    => '/install[/:version]',
         			'defaults' => array(
         				'controller' => 'Application\Controller\Home',
-        				'action'     => 'install',
+        				'action'     => 'install'
         			),
+              'constraints' => array(
+                'version' => '[0-9]+\.[0-9]+\.[0-9]+'
+              ),
         		),
         	),
         	'video' => array(

--- a/module/Application/src/Application/Controller/HomeController.php
+++ b/module/Application/src/Application/Controller/HomeController.php
@@ -17,16 +17,22 @@ class HomeController extends AbstractActionController
     public function indexAction()
     {
     	$config = $this->getServiceLocator()->get('Config');
-    	
+
         return new ViewModel(array(
         	'version'  => $config['apigility']['version'],
         	'zip' => $config['links']['zip']
         ));
     }
-    
+
     public function installAction()
     {
-    	$installer = file_get_contents(__DIR__ . '/../../../../../bin/install.php');
+      $version = $this->params()->fromRoute('version');
+      if (empty($version)) {
+    	   $installer = file_get_contents(__DIR__ . '/../../../../../bin/install.php');
+      } else {
+         $installer = file_get_contents(__DIR__ . '/../../../../../bin/install.php.dist');
+         $installer = str_replace('%VERSION%', $version, $installer);
+      }
 
     	return $this->getResponse()->setContent($installer);
     }

--- a/module/Application/view/application/download/index.phtml
+++ b/module/Application/view/application/download/index.phtml
@@ -57,6 +57,16 @@
                     </p>
 
 <div class="highlight"><pre><code class="bash"><span class="nv">$ </span>php -r "readfile('https://apigility.org/install');" | php</code></pre></div>
+
+										<h2>Install a specific version</h2>
+										
+										<p>
+												If you want to install a specific version of Apigility, you can specify the version in the previous URL path.
+												For instance, if you want to install the 1.0.0 version you need to add the /1.0.0 at the end of the URL:
+										</p>
+
+<div class="highlight"><pre><code class="bash"><span class="nv">$ </span>curl -sS https://apigility.org/install/1.0.0 | php</code></pre></div>
+
 				</div>
 			</article>
 		</div>


### PR DESCRIPTION
I added the version support to the installer, using an optional parameter in the URL:
- `/install` install the latest version (using install.php)
- `/install/x.y.z` install the x.y.z version (using install.php.dist, replacing %VERSION%)

Moreover, I added the `-ddisplay_errors=0` option to the internal PHP web server execute by the installer.